### PR TITLE
fix repeating index issue

### DIFF
--- a/src/meer21cm/stack.py
+++ b/src/meer21cm/stack.py
@@ -92,10 +92,20 @@ def stack(
             indx_0_sample.ravel(), indx_1_sample.ravel(), ch_id
         ].reshape(indx_0_sample.shape)
         # each source is added to a different channel in the final cube
-        stack_3D_map[:, :, ch_id - indx_z_g + num_ch - 1] += (
-            map_source_i * weight_source_i
+        # this is wrong because repeating indices are only added in the last occurance
+        # stack_3D_map[:, :, ch_id - indx_z_g + num_ch - 1] += (
+        #    map_source_i * weight_source_i
+        # )
+        # stack_3D_weight[:, :, ch_id - indx_z_g + num_ch - 1] += weight_source_i
+        add_id = ch_id - indx_z_g + num_ch - 1
+        # some new np black magic
+        np.add.at(stack_3D_weight, (slice(None), slice(None), add_id), weight_source_i)
+        np.add.at(
+            stack_3D_map,
+            (slice(None), slice(None), add_id),
+            weight_source_i * map_source_i,
         )
-        stack_3D_weight[:, :, ch_id - indx_z_g + num_ch - 1] += weight_source_i
+
     # average
     stack_3D_map[stack_3D_weight > 0] = (
         stack_3D_map[stack_3D_weight > 0] / stack_3D_weight[stack_3D_weight > 0]

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -54,6 +54,27 @@ def test_stack():
     assert np.allclose(np.unique(indx[1]), [10])
     average_profile = stack_3D_map[10, 10, peak_point - 4 : peak_point + 5]
     assert np.allclose(average_profile, [0, 1, 2, 3, 4, 3, 2, 1, 0])
+    # test two sources on top of each other
+    sp = Specification(
+        ra_range=ra_range_MK,
+        dec_range=dec_range_MK,
+    )
+    data = sp.data.copy()
+    source_1 = np.array([1, 2, 3, 4, 5, 4, 3, 2, 1])
+    source_avg = source_1.astype("float").copy()
+    data[80, 30, 80 - 4 : 80 + 5] += source_1
+    data[80, 30, 80 - 4 : 80 + 5] += source_1
+    ra_g = np.array([sp.ra_map[80, 30], sp.ra_map[80, 30]])
+    dec_g = np.array([sp.dec_map[80, 30], sp.dec_map[80, 30]])
+    z_g = np.array([sp.z_ch[80], sp.z_ch[80]])
+    sp._ra_gal = ra_g
+    sp._dec_gal = dec_g
+    sp._z_gal = z_g
+    sp._data = data
+    stack_3D_map, stack_3D_weight = stack(sp)
+    average_profile = stack_3D_map[10, 10, peak_point - 4 : peak_point + 5]
+    # due to double counting
+    assert np.allclose(average_profile, source_avg * 2)
 
 
 def test_raise_error():


### PR DESCRIPTION
hot fix for a stealth error in stacking. Use `numpy.add.at` instead of `numpy.ndarray.__iadd__`.