### PR TITLE
Track rng

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -138,8 +138,8 @@ jobs:
         source activate ${ENV_NAME}
         pytest --cov-config=.coveragerc --cov=meer21cm tests/ --cov-report xml:coverage.xml
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: core-tests
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/meer21cm/dataanalysis.py
+++ b/src/meer21cm/dataanalysis.py
@@ -1382,7 +1382,6 @@ class Specification:
         Create a white noise map with the given standard deviation.
         The sigma in each pixel is then scaled by the counts 1/sqrt(counts).
 
-        Note that, the default seed is **fixed** to the class attribute ``self.seed``.
         If you want to generate multiple random catalogues, you need to set a different seed manually for each catalogue.
 
         If you want to use different noise level per pixel, you can either pass a 3D
@@ -1400,7 +1399,7 @@ class Specification:
         counts: array, default None.
             The counts in each pixel. If None, the counts will be one across the cube.
         seed: int, default None.
-            The seed for the random number generator. Default uses the class attribute ``self.seed``.
+           If none, the seed is pulled from OS as described by the numpy documentation.
         inf_to_zero: bool, default True.
             If True, the inf values in the noise map will be set to zero.
         Returns

--- a/src/meer21cm/dataanalysis.py
+++ b/src/meer21cm/dataanalysis.py
@@ -234,6 +234,7 @@ class Specification:
                 "Predefined survey/band grids are WCS-only; omit hp_nside when using "
                 "survey=... and band=..., or use a non-default survey/band key."
             )
+
         self.dependency_dict = find_property_with_tags(self)
         funcs = list(chain.from_iterable(list(self.dependency_dict.values())))
         for func_i in np.unique(np.array(funcs)):

--- a/src/meer21cm/mock.py
+++ b/src/meer21cm/mock.py
@@ -130,7 +130,6 @@ class MockSimulation(PowerSpectrum):
                 "box dimensions and model power will be inconsistent"
             )
 
-    @PowerSpectrum.seed.setter
     def _set_seed(self, pseed):
         super()._set_seed(pseed)
         init_attr = [

--- a/src/meer21cm/mock.py
+++ b/src/meer21cm/mock.py
@@ -130,30 +130,6 @@ class MockSimulation(PowerSpectrum):
                 "box dimensions and model power will be inconsistent"
             )
 
-    def _set_seed(self, pseed):
-        super()._set_seed(pseed)
-        init_attr = [
-            "_halo_mass_mock_tracer",
-            "_hi_mass_mock_tracer",
-            "_hi_profile_mock_tracer",
-            "_mock_tracer_position_in_box",
-            "_mock_tracer_position_in_radecz",
-            "_mock_matter_field_r",
-            "_mock_velocity_u_matter",
-            "_mock_kaiser_field_k_matter",
-            "_mock_matter_field",
-            "_mock_tracer_field_1_r",
-            "_mock_velocity_u_tracer_1",
-            "_mock_kaiser_field_k_tracer_1",
-            "_mock_tracer_field_1",
-            "_mock_tracer_field_2_r",
-            "_mock_velocity_u_tracer_2",
-            "_mock_kaiser_field_k_tracer_2",
-            "_mock_tracer_field_2",
-            ]
-
-        self.clean_cache(init_attr)
-
     def _iter_last_axis_batches(self, axis_size):
         """
         Return stable last-axis batches for chunked processing.
@@ -412,7 +388,7 @@ class MockSimulation(PowerSpectrum):
         self.clean_cache(self.discrete_dep_attr)
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box")
+    @tagging("cosmo_model", "nu", "mock", "box", "seed")
     def mock_matter_field_r(self):
         """
         The simulated dark matter density field in real space.
@@ -422,7 +398,7 @@ class MockSimulation(PowerSpectrum):
         return self._mock_matter_field_r
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "rsd")
+    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "seed")
     def mock_matter_field(self):
         """
         The simulated dark matter density field in redshift space.
@@ -479,7 +455,7 @@ class MockSimulation(PowerSpectrum):
         return delta_x
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "rsd")
+    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "seed")
     def mock_velocity_u_matter(self):
         r"""
         The normalised peculiar velocity field in real space, defined as
@@ -497,7 +473,7 @@ class MockSimulation(PowerSpectrum):
         return self._mock_velocity_u_matter
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "tracer_1")
+    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "tracer_1", "seed")
     def mock_velocity_u_tracer_1(self):
         """
         The normalised peculiar velocity field used for the first tracer.
@@ -516,7 +492,7 @@ class MockSimulation(PowerSpectrum):
         return self._mock_velocity_u_tracer_1
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "tracer_2")
+    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "tracer_2", "seed")
     def mock_velocity_u_tracer_2(self):
         """
         The normalised peculiar velocity field used for the second tracer.
@@ -563,7 +539,7 @@ class MockSimulation(PowerSpectrum):
         return u_r
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "rsd")
+    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "seed")
     def mock_kaiser_field_k_matter(self):
         """
         The Kaiser rsd effect correction for the mock matter field in k-space.
@@ -573,7 +549,7 @@ class MockSimulation(PowerSpectrum):
         return self._mock_kaiser_field_k_matter
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "tracer_1")
+    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "tracer_1", "seed")
     def mock_kaiser_field_k_tracer_1(self):
         """
         The Kaiser rsd effect correction for the mock tracer field 1 in k-space.
@@ -585,7 +561,7 @@ class MockSimulation(PowerSpectrum):
         return self._mock_kaiser_field_k_tracer_1
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "tracer_2")
+    @tagging("cosmo_model", "nu", "mock", "box", "rsd", "tracer_2", "seed")
     def mock_kaiser_field_k_tracer_2(self):
         """
         The Kaiser rsd effect correction for the mock tracer field 2 in k-space.
@@ -717,7 +693,7 @@ class MockSimulation(PowerSpectrum):
         return self._mock_amp_2
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "tracer_1", "rsd")
+    @tagging("cosmo_model", "nu", "mock", "box", "tracer_1", "rsd", "seed")
     def mock_tracer_field_1(self):
         """
         The simulated tracer field 1 in redshift space with unit if ``mock_amp_1`` or ``mean_amp_1`` is given.
@@ -731,7 +707,7 @@ class MockSimulation(PowerSpectrum):
         return self._mock_tracer_field_1 * amp
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "tracer_2", "rsd")
+    @tagging("cosmo_model", "nu", "mock", "box", "tracer_2", "rsd", "seed")
     def mock_tracer_field_2(self):
         """
         The simulated tracer field 2 in redshift space with unit if ``mock_amp_2`` or ``mean_amp_2`` is given.
@@ -745,7 +721,7 @@ class MockSimulation(PowerSpectrum):
         return self._mock_tracer_field_2 * amp
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "tracer_1")
+    @tagging("cosmo_model", "nu", "mock", "box", "tracer_1", "seed")
     def mock_tracer_field_1_r(self):
         """
         The simulated tracer field 1 **unitsless density contrast** in real space.
@@ -755,7 +731,7 @@ class MockSimulation(PowerSpectrum):
         return self._mock_tracer_field_1_r
 
     @property
-    @tagging("cosmo_model", "nu", "mock", "box", "tracer_2")
+    @tagging("cosmo_model", "nu", "mock", "box", "tracer_2", "seed")
     def mock_tracer_field_2_r(self):
         """
         The simulated tracer field 2 **unitsless density contrast** in real space.
@@ -821,7 +797,15 @@ class MockSimulation(PowerSpectrum):
 
     @property
     @tagging(
-        "cosmo_model", "nu", "mock", "box", "tracer_1", "tracer_2", "discrete", "rsd"
+        "cosmo_model",
+        "nu",
+        "mock",
+        "box",
+        "tracer_1",
+        "tracer_2",
+        "discrete",
+        "rsd",
+        "seed",
     )
     def mock_tracer_position_in_box(self):
         """
@@ -911,7 +895,15 @@ class MockSimulation(PowerSpectrum):
 
     @property
     @tagging(
-        "cosmo_model", "nu", "mock", "box", "tracer_1", "tracer_2", "discrete", "rsd"
+        "cosmo_model",
+        "nu",
+        "mock",
+        "box",
+        "tracer_1",
+        "tracer_2",
+        "discrete",
+        "rsd",
+        "seed",
     )
     def mock_tracer_position_in_radecz(self):
         """
@@ -1308,6 +1300,7 @@ class HIGalaxySimulation(MockSimulation):
         "tracer_2",
         "discrete",
         "rsd",
+        "seed",
     )
     def halo_mass_mock_tracer(self):
         """
@@ -1365,6 +1358,7 @@ class HIGalaxySimulation(MockSimulation):
         "discrete",
         "rsd",
         "himass",
+        "seed",
     )
     def hi_mass_mock_tracer(self):
         """
@@ -1400,6 +1394,7 @@ class HIGalaxySimulation(MockSimulation):
         "rsd",
         "himass",
         "hivel",
+        "seed",
     )
     def hi_profile_mock_tracer(self):
         """

--- a/src/meer21cm/mock.py
+++ b/src/meer21cm/mock.py
@@ -130,6 +130,31 @@ class MockSimulation(PowerSpectrum):
                 "box dimensions and model power will be inconsistent"
             )
 
+    @PowerSpectrum.seed.setter
+    def _set_seed(self, pseed):
+        super()._set_seed(pseed)
+        init_attr = [
+            "_halo_mass_mock_tracer",
+            "_hi_mass_mock_tracer",
+            "_hi_profile_mock_tracer",
+            "_mock_tracer_position_in_box",
+            "_mock_tracer_position_in_radecz",
+            "_mock_matter_field_r",
+            "_mock_velocity_u_matter",
+            "_mock_kaiser_field_k_matter",
+            "_mock_matter_field",
+            "_mock_tracer_field_1_r",
+            "_mock_velocity_u_tracer_1",
+            "_mock_kaiser_field_k_tracer_1",
+            "_mock_tracer_field_1",
+            "_mock_tracer_field_2_r",
+            "_mock_velocity_u_tracer_2",
+            "_mock_kaiser_field_k_tracer_2",
+            "_mock_tracer_field_2",
+            ]
+
+        self.clean_cache(init_attr)
+
     def _iter_last_axis_batches(self, axis_size):
         """
         Return stable last-axis batches for chunked processing.

--- a/src/meer21cm/power.py
+++ b/src/meer21cm/power.py
@@ -2344,15 +2344,15 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
         self.flat_sky_padding = flat_sky_padding
         self.k1dweights = k1dweights
 
+    def _set_seed(self, pseed):
+        self._seed = pseed
+
     @property
     def seed(self):
         """
         seed value for RNG calls throughout the code.
         """
         return self._seed
-
-    def _set_seed(self, pseed):
-        self._seed = pseed
 
     @seed.setter
     def seed(self, pseed):

--- a/src/meer21cm/power.py
+++ b/src/meer21cm/power.py
@@ -2347,7 +2347,7 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
     @property
     def seed(self):
         """
-        seed value for RNG calls throughout the code.
+        Seed value for RNG calls throughout the instance.
         """
         return self._seed
 
@@ -3544,8 +3544,7 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
     def gen_random_poisson_galaxy(self, sel=None, num_g_rand=None, seed=None):
         """
         Generate a random galaxy catalogue from the map cube following the Poisson distribution.
-
-        Note that, by default, the random seed is fixed to the class attribute ``self.seed``.
+        The generation of the sample does not use the instance seed if not explicitly passed and will use a random one otherwise.
         If you want to generate multiple random catalogues, you need to set a different seed manually for each catalogue.
 
         Parameters
@@ -3556,7 +3555,7 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
         num_g_rand: int, default None
             The number of galaxies to generate. Default uses the number of galaxies stored in the data in `self.ra_gal`.
         seed: int, default None
-            The seed for the random number generator. Default uses the class attribute ``self.seed``.
+            The seed for the random number generator.
 
         Returns
         -------
@@ -3572,8 +3571,6 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
             sel = self.W_HI[:, :, 0]
         if num_g_rand is None:
             num_g_rand = self.ra_gal.size
-        if seed is None:
-            seed = self.seed
         rng = np.random.default_rng(seed=seed)
         ra_rand = self.ra_map[sel]
         dec_rand = self.dec_map[sel]

--- a/src/meer21cm/power.py
+++ b/src/meer21cm/power.py
@@ -2345,6 +2345,22 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
         self.k1dweights = k1dweights
 
     @property
+    def seed(self):
+        """
+        seed value for RNG calls throughout the code.
+        """
+        return self._seed
+
+    def _set_seed(self, pseed):
+        self._seed = pseed
+
+    @seed.setter
+    def seed(self, pseed):
+        self._set_seed(pseed)
+        # The only quantity in this class that uses the seed is
+        # get_enclosing box which does not need recomputing (probably)
+
+    @property
     def box_buffkick(self):
         """
         The buffer kick for the box on each side when gridding. In the unit of Mpc.
@@ -3559,6 +3575,8 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
             sel = self.W_HI[:, :, 0]
         if num_g_rand is None:
             num_g_rand = self.ra_gal.size
+        if seed is None:
+            seed = self.seed
         rng = np.random.default_rng(seed=seed)
         ra_rand = self.ra_map[sel]
         dec_rand = self.dec_map[sel]

--- a/src/meer21cm/power.py
+++ b/src/meer21cm/power.py
@@ -2354,7 +2354,8 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
     @seed.setter
     def seed(self, pseed):
         self._seed = pseed
-        self.clean_cache(self.seed_dep_attr)
+        if "seed_dep_attr" in dir(self):
+            self.clean_cache(self.seed_dep_attr)
 
     @property
     def box_buffkick(self):

--- a/src/meer21cm/power.py
+++ b/src/meer21cm/power.py
@@ -2344,9 +2344,6 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
         self.flat_sky_padding = flat_sky_padding
         self.k1dweights = k1dweights
 
-    def _set_seed(self, pseed):
-        self._seed = pseed
-
     @property
     def seed(self):
         """
@@ -2356,9 +2353,8 @@ class PowerSpectrum(FieldPowerSpectrum, ModelPowerSpectrum):
 
     @seed.setter
     def seed(self, pseed):
-        self._set_seed(pseed)
-        # The only quantity in this class that uses the seed is
-        # get_enclosing box which does not need recomputing (probably)
+        self._seed = pseed
+        self.clean_cache(self.seed_dep_attr)
 
     @property
     def box_buffkick(self):

--- a/src/meer21cm/util.py
+++ b/src/meer21cm/util.py
@@ -1247,7 +1247,9 @@ def cal_himf(x, mmin, cosmo, mmax=11, integrate_step=500):
     marr = np.logspace(mmin, mmax, num=integrate_step)
     omegahi = (
         (
-            np.trapz(himf(np.log10(marr), x[0], x[1], x[2]) * marr, x=np.log10(marr))
+            np.trapezoid(
+                himf(np.log10(marr), x[0], x[1], x[2]) * marr, x=np.log10(marr)
+            )
             * units.M_sun
             / units.Mpc**3
             / cosmo.critical_density0
@@ -1256,10 +1258,13 @@ def cal_himf(x, mmin, cosmo, mmax=11, integrate_step=500):
         .value
     )
     psn = (
-        np.trapz(himf(np.log10(marr), x[0], x[1], x[2]) * marr**2, x=np.log10(marr))
-        / np.trapz(himf(np.log10(marr), x[0], x[1], x[2]) * marr, x=np.log10(marr)) ** 2
+        np.trapezoid(
+            himf(np.log10(marr), x[0], x[1], x[2]) * marr**2, x=np.log10(marr)
+        )
+        / np.trapezoid(himf(np.log10(marr), x[0], x[1], x[2]) * marr, x=np.log10(marr))
+        ** 2
     )
-    nhi = np.trapz(himf(np.log10(marr), x[0], x[1], x[2]), x=np.log10(marr))
+    nhi = np.trapezoid(himf(np.log10(marr), x[0], x[1], x[2]), x=np.log10(marr))
     return nhi, omegahi, psn
 
 
@@ -1312,7 +1317,7 @@ def cumu_nhi_from_himf(m, mmin, x):
             The integrated number density of HI galaxies, in the units of phi_s * dex
     """
     marr = np.logspace(mmin, m, num=500)
-    nhi = np.trapz(himf(np.log10(marr), x[0], x[1], x[2]), x=np.log10(marr), axis=0)
+    nhi = np.trapezoid(himf(np.log10(marr), x[0], x[1], x[2]), x=np.log10(marr), axis=0)
     return nhi
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -135,7 +135,7 @@ def test_project_function():
     for scheme in allowed_window_scheme:
         s_arr = np.linspace(-1.5, 1.5, 601)
         weight_arr = project_function(s_arr, scheme)
-        assert np.abs(np.trapz(weight_arr, s_arr) - 1) < 1e-2
+        assert np.abs(np.trapezoid(weight_arr, x=s_arr) - 1) < 1e-2
         s_test = 0.25
         func_value = project_function(s_test, scheme)
         if scheme == "nnb":

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -16,6 +16,23 @@ from scipy.signal import windows
 from scipy.interpolate import interp1d
 
 
+def test_seed_clean_cache():
+    mock = MockSimulation(
+        survey="meerklass_2021",
+        band="L",
+        kaiser_rsd=True,
+        parallel_plane=True,
+        density="lognormal",
+        tracer_bias_2=1.5,
+    )
+    mock.seed = 42
+    field_1 = np.array(mock.mock_tracer_field_1)
+    mock.seed = 43
+    assert mock._mock_tracer_field_1 is None
+    field_2 = np.array(mock.mock_tracer_field_2)
+    assert not np.allclose(field_1, field_2)
+
+
 @pytest.mark.parametrize("parallel_plane", [True, False])
 def test_rsd_from_field(parallel_plane):
     # rsd from field only works at quite large scales


### PR DESCRIPTION
This PR adds the seed as a tagged quantity. This allows for recomputing simulations without recomputing field-independent quantities. Also, allows for a generalisation for all RNG calls in the code.